### PR TITLE
Scrum 26 post viewing history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 # Logs
 logs
 *.log

--- a/services/file/File Service Complete.postman_collection.json
+++ b/services/file/File Service Complete.postman_collection.json
@@ -1,0 +1,388 @@
+{
+  "info": {
+    "name": "Forum File Service - Complete",
+    "description": "Complete API collection for Forum File Service with S3 integration, including upload, retrieve, and error testing",
+    "version": "1.1.0",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080",
+      "type": "string"
+    },
+    {
+      "key": "userId",
+      "value": "123",
+      "type": "string"
+    },
+    {
+      "key": "authToken",
+      "value": "Bearer demo-{{userId}}",
+      "type": "string"
+    },
+    {
+      "key": "uploadedObjectKey",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "1. Health Check",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test('Response has correct structure', function () {",
+              "    const jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property('status', 'ok');",
+              "    pm.expect(jsonData).to.have.property('service', 'forum-file-service');",
+              "    pm.expect(jsonData).to.have.property('version');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/health",
+          "host": ["{{baseUrl}}"],
+          "path": ["health"]
+        },
+        "description": "Check if the File Service is running and healthy"
+      },
+      "response": []
+    },
+    {
+      "name": "2. Presign Upload (Profile Image)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 201', function () {",
+              "    pm.response.to.have.status(201);",
+              "});",
+              "",
+              "pm.test('Response has required fields', function () {",
+              "    const jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property('uploadMethod', 'PUT');",
+              "    pm.expect(jsonData).to.have.property('uploadUrl');",
+              "    pm.expect(jsonData).to.have.property('headers');",
+              "    pm.expect(jsonData).to.have.property('objectKey');",
+              "    pm.expect(jsonData).to.have.property('fileUrl');",
+              "    pm.expect(jsonData).to.have.property('expiresInSeconds', 600);",
+              "    ",
+              "    // Store objectKey for later use",
+              "    pm.collectionVariables.set('uploadedObjectKey', jsonData.objectKey);",
+              "});",
+              "",
+              "pm.test('Object key has correct format', function () {",
+              "    const jsonData = pm.response.json();",
+              "    const userId = pm.collectionVariables.get('userId');",
+              "    pm.expect(jsonData.objectKey).to.match(new RegExp(`^u/${userId}/profile/\\\\d{4}/\\\\d{2}/.+\\\\.png$`));",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "{{authToken}}",
+            "type": "text"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"filename\": \"avatar.png\",\n  \"contentType\": \"image/png\",\n  \"sizeBytes\": 183421,\n  \"category\": \"profile\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/files/presign",
+          "host": ["{{baseUrl}}"],
+          "path": ["files", "presign"]
+        },
+        "description": "Request a presigned URL for uploading a profile image"
+      },
+      "response": []
+    },
+    {
+      "name": "3. Direct Upload (Profile Image)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 201', function () {",
+              "    pm.response.to.have.status(201);",
+              "});",
+              "",
+              "pm.test('Response has required fields', function () {",
+              "    const jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property('fileUrl');",
+              "    pm.expect(jsonData).to.have.property('objectKey');",
+              "    pm.expect(jsonData).to.have.property('sizeBytes');",
+              "    pm.expect(jsonData).to.have.property('contentType');",
+              "    ",
+              "    // Store objectKey for retrieval test",
+              "    pm.collectionVariables.set('uploadedObjectKey', jsonData.objectKey);",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "{{authToken}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {
+              "key": "file",
+              "type": "file",
+              "src": [],
+              "description": "Select a small image file (PNG/JPEG, <5MB)"
+            },
+            {
+              "key": "category",
+              "value": "profile",
+              "type": "text"
+            }
+          ]
+        },
+        "url": {
+          "raw": "{{baseUrl}}/files/upload",
+          "host": ["{{baseUrl}}"],
+          "path": ["files", "upload"]
+        },
+        "description": "Upload a file directly through the service to S3"
+      },
+      "response": []
+    },
+    {
+      "name": "4. Retrieve File",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Status code is 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test('Response has required fields', function () {",
+              "    const jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property('objectKey');",
+              "    pm.expect(jsonData).to.have.property('metadata');",
+              "    pm.expect(jsonData).to.have.property('downloadUrl');",
+              "    pm.expect(jsonData).to.have.property('expiresInSeconds', 3600);",
+              "});",
+              "",
+              "pm.test('Metadata has correct structure', function () {",
+              "    const jsonData = pm.response.json();",
+              "    pm.expect(jsonData.metadata).to.have.property('size');",
+              "    pm.expect(jsonData.metadata).to.have.property('contentType');",
+              "    pm.expect(jsonData.metadata).to.have.property('lastModified');",
+              "    pm.expect(jsonData.metadata).to.have.property('serverSideEncryption');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "{{authToken}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/files/retrieve/{{uploadedObjectKey}}",
+          "host": ["{{baseUrl}}"],
+          "path": ["files", "retrieve", "{{uploadedObjectKey}}"]
+        },
+        "description": "Retrieve file metadata and get a presigned download URL. Run after uploading a file to populate the objectKey variable."
+      },
+      "response": []
+    },
+    {
+      "name": "5. Error Tests",
+      "item": [
+        {
+          "name": "Unauthorized Request",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 401', function () {",
+                  "    pm.response.to.have.status(401);",
+                  "});",
+                  "",
+                  "pm.test('Error response structure', function () {",
+                  "    const jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property('traceId');",
+                  "    pm.expect(jsonData).to.have.property('error');",
+                  "    pm.expect(jsonData.error).to.have.property('code', 'UNAUTHORIZED');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"filename\": \"test.png\",\n  \"contentType\": \"image/png\",\n  \"sizeBytes\": 1024,\n  \"category\": \"profile\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/files/presign",
+              "host": ["{{baseUrl}}"],
+              "path": ["files", "presign"]
+            },
+            "description": "Test authentication requirement - should return 401"
+          },
+          "response": []
+        },
+        {
+          "name": "File Too Large",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 413', function () {",
+                  "    pm.response.to.have.status(413);",
+                  "});",
+                  "",
+                  "pm.test('Error response structure', function () {",
+                  "    const jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property('error');",
+                  "    pm.expect(jsonData.error).to.have.property('code', 'PAYLOAD_TOO_LARGE');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "{{authToken}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"filename\": \"large-file.png\",\n  \"contentType\": \"image/png\",\n  \"sizeBytes\": 6000000,\n  \"category\": \"profile\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/files/presign",
+              "host": ["{{baseUrl}}"],
+              "path": ["files", "presign"]
+            },
+            "description": "Test file size limit - profile images must be ≤5MB"
+          },
+          "response": []
+        },
+        {
+          "name": "File Not Found",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status code is 404', function () {",
+                  "    pm.response.to.have.status(404);",
+                  "});",
+                  "",
+                  "pm.test('Error response structure', function () {",
+                  "    const jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property('error');",
+                  "    pm.expect(jsonData.error).to.have.property('code', 'NOT_FOUND');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "{{authToken}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/files/retrieve/u/{{userId}}/profile/2025/09/nonexistent.png",
+              "host": ["{{baseUrl}}"],
+              "path": ["files", "retrieve", "u", "{{userId}}", "profile", "2025", "09", "nonexistent.png"]
+            },
+            "description": "Test retrieving a file that doesn't exist"
+          },
+          "response": []
+        }
+      ],
+      "description": "Collection of error test cases to validate proper error handling"
+    }
+  ]
+}

--- a/services/file/File Service Environment.postman_environment.json
+++ b/services/file/File Service Environment.postman_environment.json
@@ -1,0 +1,43 @@
+{
+  "id": "file-service-env",
+  "name": "File Service Environment",
+  "values": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "userId",
+      "value": "123",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "authToken",
+      "value": "Bearer demo-123",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "uploadedObjectKey",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "presignedUploadUrl",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "downloadUrl",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/services/history/fa-history.postman_collection.json
+++ b/services/history/fa-history.postman_collection.json
@@ -1,0 +1,151 @@
+{
+  "info": {
+    "name": "fa-history",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "base_url", "value": "http://127.0.0.1:8091", "type": "string" },
+    { "key": "user_id", "value": "user123", "type": "string" },
+    { "key": "jwt_secret", "value": "devsecret", "type": "string" },
+    { "key": "jwt", "value": "", "type": "string" },
+    { "key": "post_id_published", "value": "c2ef7b85-eb35-4de3-8dd6-30c66bd465f4", "type": "string" },
+    { "key": "post_id_published2", "value": "6d1c08e5-f0ce-4b55-8f92-f226b5fa7926", "type": "string" },
+    { "key": "post_id_draft", "value": "9eed7271-30b9-4030-bb17-8be88e9fa2bc", "type": "string" },
+    { "key": "last_history_id", "value": "", "type": "string" }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Generate HS256 JWT for Authorization using modern crypto API",
+          "function b64url(obj){",
+          "  const json = (typeof obj === 'string') ? obj : JSON.stringify(obj);",
+          "  const b64 = btoa(json);",
+          "  return b64.replace(/=+$/,'').replace(/\\+/g,'-').replace(/\\//g,'_');",
+          "}",
+          "",
+          "async function hmacSha256(key, data) {",
+          "  const encoder = new TextEncoder();",
+          "  const keyData = encoder.encode(key);",
+          "  const dataBuffer = encoder.encode(data);",
+          "  const cryptoKey = await crypto.subtle.importKey(",
+          "    'raw', keyData, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']",
+          "  );",
+          "  const signature = await crypto.subtle.sign('HMAC', cryptoKey, dataBuffer);",
+          "  return btoa(String.fromCharCode(...new Uint8Array(signature)));",
+          "}",
+          "",
+          "const header = { alg: 'HS256', typ: 'JWT' };",
+          "const payload = { sub: pm.collectionVariables.get('user_id') || 'user123', emailVerified: true };",
+          "const encHeader = b64url(header);",
+          "const encPayload = b64url(payload);",
+          "const secret = pm.collectionVariables.get('jwt_secret') || 'devsecret';",
+          "const signingInput = encHeader + '.' + encPayload;",
+          "",
+          "hmacSha256(secret, signingInput).then(sig => {",
+          "  const encSig = sig.replace(/=+$/,'').replace(/\\+/g,'-').replace(/\\//g,'_');",
+          "  pm.collectionVariables.set('jwt', encHeader + '.' + encPayload + '.' + encSig);",
+          "}).catch(err => {",
+          "  console.error('JWT generation failed:', err);",
+          "  // Fallback: set a placeholder token",
+          "  pm.collectionVariables.set('jwt', 'GENERATE_JWT_MANUALLY');",
+          "});"
+        ]
+      }
+    }
+  ],
+  "item": [
+    {
+      "name": "Health",
+      "request": {
+        "method": "GET",
+        "url": { "raw": "{{base_url}}/health", "host": ["{{base_url}}"], "path": ["health"] }
+      }
+    },
+    {
+      "name": "Record View (Published)",
+      "request": {
+        "method": "POST",
+        "header": [ { "key": "Authorization", "value": "Bearer {{jwt}}" }, { "key": "Content-Type", "value": "application/json" } ],
+        "url": { "raw": "{{base_url}}/history/views", "host": ["{{base_url}}"], "path": ["history","views"] },
+        "body": { "mode": "raw", "raw": "{\n  \"postId\": \"{{post_id_published}}\",\n  \"searchTerm\": \"Postman test\"\n}" }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status is 200/201', function(){ pm.expect([200,201]).to.include(pm.response.code); });",
+              "try { var id = pm.response.json().historyId; if (id) pm.collectionVariables.set('last_history_id', id); } catch(e) {}"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Record View (Draft - expect 403)",
+      "request": {
+        "method": "POST",
+        "header": [ { "key": "Authorization", "value": "Bearer {{jwt}}" }, { "key": "Content-Type", "value": "application/json" } ],
+        "url": { "raw": "{{base_url}}/history/views", "host": ["{{base_url}}"], "path": ["history","views"] },
+        "body": { "mode": "raw", "raw": "{\n  \"postId\": \"{{post_id_draft}}\",\n  \"searchTerm\": \"should be blocked\"\n}" }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": { "type": "text/javascript", "exec": ["pm.test('Status is 403', function(){ pm.expect(pm.response.code).to.eql(403); });"] }
+        }
+      ]
+    },
+    {
+      "name": "List History",
+      "request": {
+        "method": "GET",
+        "header": [ { "key": "Authorization", "value": "Bearer {{jwt}}" } ],
+        "url": {
+          "raw": "{{base_url}}/history?limit=10",
+          "host": ["{{base_url}}"],
+          "path": ["history"],
+          "query": [ {"key":"limit","value":"10"} ]
+        }
+      }
+    },
+    {
+      "name": "Stats",
+      "request": {
+        "method": "GET",
+        "header": [ { "key": "Authorization", "value": "Bearer {{jwt}}" } ],
+        "url": { "raw": "{{base_url}}/history/stats", "host": ["{{base_url}}"], "path": ["history","stats"] }
+      }
+    },
+    {
+      "name": "Delete One (uses last_history_id)",
+      "request": {
+        "method": "DELETE",
+        "header": [ { "key": "Authorization", "value": "Bearer {{jwt}}" } ],
+        "url": { "raw": "{{base_url}}/history/{{last_history_id}}", "host": ["{{base_url}}"], "path": ["history","{{last_history_id}}"] }
+      }
+    },
+    {
+      "name": "Delete All",
+      "request": {
+        "method": "DELETE",
+        "header": [ { "key": "Authorization", "value": "Bearer {{jwt}}" } ],
+        "url": { "raw": "{{base_url}}/history", "host": ["{{base_url}}"], "path": ["history"] }
+      }
+    },
+    {
+      "name": "Record View (Published #2)",
+      "request": {
+        "method": "POST",
+        "header": [ { "key": "Authorization", "value": "Bearer {{jwt}}" }, { "key": "Content-Type", "value": "application/json" } ],
+        "url": { "raw": "{{base_url}}/history/views", "host": ["{{base_url}}"], "path": ["history","views"] },
+        "body": { "mode": "raw", "raw": "{\n  \"postId\": \"{{post_id_published2}}\",\n  \"searchTerm\": \"Postman test #2\"\n}" }
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
Added Postman collection for fa-history with JWT pre-request script
Endpoints covered:
Health
Record View (Published)
Record View (Draft – expect 403)
List History (with pagination)
Stats
Delete One (uses last_history_id)
Delete All
Record View (Published #2)